### PR TITLE
Route PR webhook selection via GitHub Actions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "5 15 * * *"
   workflow_dispatch: {}
+  pull_request: {}
 
 jobs:
   run-daily:
@@ -32,5 +33,5 @@ jobs:
       - name: Run daily job
         env:
           NCFA_TOKEN: ${{ secrets.NCFA_TOKEN }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WEBHOOK_URL: ${{ github.event_name == 'pull_request' && secrets.DISCORD_WEBHOOK_URL_PR || secrets.DISCORD_WEBHOOK_URL }}
         run: npm run start

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Fetch today’s GeoGuessr Daily Challenge friends leaderboard and post it to a D
 - Node.js 20+
 - A GeoGuessr session cookie
 - A Discord webhook URL
+- (Optional) A Discord webhook URL for pull request runs (GitHub Actions secret)
 
 ## Setup
 
@@ -31,6 +32,8 @@ Fetch today’s GeoGuessr Daily Challenge friends leaderboard and post it to a D
 1. In Discord, go to your server → **Edit Channel** → **Integrations**.
 2. Create a **Webhook**, select the target channel, and copy the URL.
 3. Store it in `DISCORD_WEBHOOK_URL`.
+4. (Optional) For GitHub pull request runs, store a private test webhook URL in
+   the `DISCORD_WEBHOOK_URL_PR` Actions secret so PRs post to a safe channel.
 
 ### 3) Local Run
 
@@ -38,6 +41,10 @@ Fetch today’s GeoGuessr Daily Challenge friends leaderboard and post it to a D
 npm install
 GEOGUESSR_COOKIE="..." DISCORD_WEBHOOK_URL="..." npm run start
 ```
+
+For pull request CI runs, set the `DISCORD_WEBHOOK_URL_PR` GitHub Actions secret.
+The workflow uses it to route PR runs to the test webhook while still using
+`DISCORD_WEBHOOK_URL` for scheduled runs.
 
 ### Distance Assumption
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ async function writeLastToken(token: string): Promise<void> {
 
 async function run(): Promise<void> {
   const cookie = getAuthCookie();
-  const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL?.trim();
 
   if (!webhookUrl) {
     throw new Error("Missing DISCORD_WEBHOOK_URL environment variable.");


### PR DESCRIPTION
### Motivation
- Ensure pull request CI runs post to a private/test Discord webhook without changing runtime app logic.
- Move PR routing responsibility from application code into the GitHub Actions workflow to avoid accidental public posts and simplify the runtime environment.

### Description
- Removed the PR-detection and dual-webhook selection logic from `src/index.ts` and restored use of a single runtime `DISCORD_WEBHOOK_URL` environment variable.
- Added `pull_request` to the workflow triggers and updated `.github/workflows/daily.yml` to set `DISCORD_WEBHOOK_URL` via a conditional that uses `secrets.DISCORD_WEBHOOK_URL_PR` for PR runs or `secrets.DISCORD_WEBHOOK_URL` otherwise.
- Updated `README.md` to document `DISCORD_WEBHOOK_URL_PR` as a GitHub Actions secret and clarified routing behavior, and adjusted `.env.example` to remove the PR webhook entry.

### Testing
- No automated tests were run for this change.
- The workflow change is exercised via GitHub Actions conditional environment selection and should be validated by running the workflow in a PR and a scheduled run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a86f6abdc83208e6483f26fcfb797)