### PR TITLE
Skip discord post when no daily completions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,11 @@ async function run(): Promise<void> {
     return;
   }
 
+  if (daily.results.length === 0) {
+    console.log("No completed daily challenges yet. Skipping Discord post.");
+    return;
+  }
+
   const message = buildLeaderboardMessage(daily);
   await postDiscordMessage(webhookUrl, message);
   await writeLastToken(cacheKey);


### PR DESCRIPTION
### Motivation
- Avoid sending an empty leaderboard message to Discord when nobody has completed the GeoGuessr Daily, and avoid creating a cache entry for an unchanged/empty result set.

### Description
- Add a guard in `src/index.ts` after fetching daily results that checks `daily.results.length === 0` and logs `No completed daily challenges yet. Skipping Discord post.` then returns instead of calling `postDiscordMessage` and `writeLastToken`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb31782388320a535387e8113c56c)