### PR TITLE
Adjust leaderboard output formatting

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -45,14 +45,35 @@ function formatRoundLocations(
   return lines.join("\n");
 }
 
-function formatRoundResults(
+function formatRoundResultsTable(
   roundResults: DailyFriendRoundResult[]
 ): string[] {
-  return roundResults.map((round) => {
-    const guess = round.guessedCountry ?? "Unknown";
-
-    return `${round.round} | ${round.steps} | ${round.score} | ${guess}`;
+  const headers = ["Round", "Steps", "Score", "Guess"];
+  const rows = roundResults.map((round) => {
+    return [
+      round.round.toString(),
+      round.steps.toString(),
+      round.score.toString(),
+      round.guessedCountry ?? "Unknown"
+    ];
   });
+
+  const widths = headers.map((header, index) => {
+    const cellWidths = rows.map((row) => row[index].length);
+    return Math.max(header.length, ...cellWidths);
+  });
+
+  const padRow = (cells: string[]) => {
+    return cells
+      .map((cell, index) => cell.padEnd(widths[index]))
+      .join(" | ");
+  };
+
+  const headerLine = padRow(headers);
+  const dividerLine = widths.map((width) => "-".repeat(width)).join(" | ");
+  const dataLines = rows.map(padRow);
+
+  return [headerLine, dividerLine, ...dataLines];
 }
 
 function formatPlayerBreakdowns(entries: DailyFriendResult[]): string | null {
@@ -76,9 +97,7 @@ function formatPlayerBreakdowns(entries: DailyFriendResult[]): string | null {
     }
 
     lines.push(friend.nick);
-    lines.push("Round | Steps | Score | Guess");
-    lines.push("----- | ----- | ----- | -----");
-    lines.push(...formatRoundResults(friend.roundResults));
+    lines.push(...formatRoundResultsTable(friend.roundResults));
     lines.push(
       `Total: ${totalScore} pts | ${totalSteps} steps | ${totalTime} | ${totalDistance} km`
     );

--- a/src/format.ts
+++ b/src/format.ts
@@ -77,7 +77,7 @@ function formatRoundResultsTable(
 }
 
 function formatPlayerBreakdowns(entries: DailyFriendResult[]): string | null {
-  const lines: string[] = [];
+  const sections: string[] = [];
   for (const friend of entries) {
     const totalScore = Math.round(friend.totalScore).toString();
     const totalTime = formatTime(friend.totalTime);
@@ -85,34 +85,27 @@ function formatPlayerBreakdowns(entries: DailyFriendResult[]): string | null {
     const totalSteps = friend.roundResults?.reduce((sum, round) => {
       return sum + round.steps;
     }, 0) ?? 0;
+    const totalsLine =
+      `Total: ${totalScore}pts | ${totalSteps}st | ${totalTime} | ${totalDistance}km`;
 
     if (!friend.roundResults || friend.roundResults.length === 0) {
-      lines.push(friend.nick);
-      lines.push("No round data.");
-      lines.push(
-        `Total: ${totalScore} pts | ${totalSteps} steps | ${totalTime} | ${totalDistance} km`
-      );
-      lines.push("");
+      const block = ["No round data.", totalsLine].join("\n");
+      sections.push(`**${friend.nick}**\n${wrapCodeBlock(block)}`);
       continue;
     }
 
-    lines.push(friend.nick);
-    lines.push(...formatRoundResultsTable(friend.roundResults));
-    lines.push(
-      `Total: ${totalScore} pts | ${totalSteps} steps | ${totalTime} | ${totalDistance} km`
-    );
-    lines.push("");
+    const tableLines = [
+      ...formatRoundResultsTable(friend.roundResults),
+      totalsLine
+    ];
+    sections.push(`**${friend.nick}**\n${wrapCodeBlock(tableLines.join("\n"))}`);
   }
 
-  while (lines.length > 0 && lines[lines.length - 1] === "") {
-    lines.pop();
-  }
-
-  if (lines.length === 0) {
+  if (sections.length === 0) {
     return null;
   }
 
-  return lines.join("\n");
+  return sections.join("\n\n");
 }
 
 function wrapCodeBlock(content: string): string {
@@ -153,9 +146,7 @@ export function buildLeaderboardMessage(daily: DailyChallengeResults): string {
 
   const playerBreakdowns = formatPlayerBreakdowns(sorted);
   if (playerBreakdowns) {
-    sections.push(
-      `**Player Round Breakdowns**\n${wrapCodeBlock(playerBreakdowns)}`
-    );
+    sections.push(`**Player Round Breakdowns**\n${playerBreakdowns}`);
   } else {
     sections.push(
       `**Player Round Breakdowns**\n${wrapCodeBlock(

--- a/src/format.ts
+++ b/src/format.ts
@@ -86,7 +86,7 @@ function formatPlayerBreakdowns(entries: DailyFriendResult[]): string | null {
       return sum + round.steps;
     }, 0) ?? 0;
     const totalsLine =
-      `Total: ${totalScore}pts | ${totalSteps}steps | ${totalTime} | ${totalDistance}km`;
+      `Total:\n ${totalScore} pts | ${totalSteps} steps | ${totalTime} | ${totalDistance} km`;
 
     if (!friend.roundResults || friend.roundResults.length === 0) {
       const block = ["No round data.", totalsLine].join("\n");

--- a/src/format.ts
+++ b/src/format.ts
@@ -17,9 +17,11 @@ function formatDistance(value: number): string {
 }
 
 function buildLeaderboardSummary(entries: DailyFriendResult[]): string {
+  const medals = ["🥇", "🥈", "🥉"];
   const lines = entries.map((friend, index) => {
     const score = Math.round(friend.totalScore).toString();
-    return `${index + 1}. ${friend.nick} — ${score} pts`;
+    const medal = medals[index] ? `${medals[index]} ` : "";
+    return `${index + 1}. ${medal}${friend.nick} — ${score} pts`;
   });
 
   return lines.join("\n");
@@ -33,12 +35,11 @@ function formatRoundLocations(
   }
 
   const lines = locations.map((round) => {
-    const coords = `${round.lat.toFixed(4)}, ${round.lng.toFixed(4)}`;
     if (round.locationName) {
-      return `- R${round.round}: ${round.locationName}\n  (${coords})`;
+      return `- R${round.round}: ${round.locationName}`;
     }
 
-    return `- R${round.round}: (${coords})`;
+    return `- R${round.round}: Unknown location`;
   });
 
   return lines.join("\n");
@@ -48,11 +49,9 @@ function formatRoundResults(
   roundResults: DailyFriendRoundResult[]
 ): string[] {
   return roundResults.map((round) => {
-    const guess = round.guessedCountry
-      ? `guess ${round.guessedCountry}`
-      : "guess unknown";
+    const guess = round.guessedCountry ?? "Unknown";
 
-    return `- R${round.round}: ${formatTime(round.time)} • steps ${round.steps} • score ${round.score} • ${guess}`;
+    return `${round.round} | ${round.steps} | ${round.score} | ${guess}`;
   });
 }
 
@@ -62,18 +61,27 @@ function formatPlayerBreakdowns(entries: DailyFriendResult[]): string | null {
     const totalScore = Math.round(friend.totalScore).toString();
     const totalTime = formatTime(friend.totalTime);
     const totalDistance = formatDistance(friend.totalDistance);
+    const totalSteps = friend.roundResults?.reduce((sum, round) => {
+      return sum + round.steps;
+    }, 0) ?? 0;
 
     if (!friend.roundResults || friend.roundResults.length === 0) {
-      lines.push(`**${friend.nick}**`);
-      lines.push("_No round data._");
-      lines.push(`Total: ${totalScore} pts • ${totalTime} • ${totalDistance} km`);
+      lines.push(friend.nick);
+      lines.push("No round data.");
+      lines.push(
+        `Total: ${totalScore} pts | ${totalSteps} steps | ${totalTime} | ${totalDistance} km`
+      );
       lines.push("");
       continue;
     }
 
-    lines.push(`**${friend.nick}**`);
+    lines.push(friend.nick);
+    lines.push("Round | Steps | Score | Guess");
+    lines.push("----- | ----- | ----- | -----");
     lines.push(...formatRoundResults(friend.roundResults));
-    lines.push(`Total: ${totalScore} pts • ${totalTime} • ${totalDistance} km`);
+    lines.push(
+      `Total: ${totalScore} pts | ${totalSteps} steps | ${totalTime} | ${totalDistance} km`
+    );
     lines.push("");
   }
 
@@ -86,6 +94,10 @@ function formatPlayerBreakdowns(entries: DailyFriendResult[]): string | null {
   }
 
   return lines.join("\n");
+}
+
+function wrapCodeBlock(content: string): string {
+  return `\`\`\`\n${content}\n\`\`\``;
 }
 
 export function buildLeaderboardMessage(daily: DailyChallengeResults): string {
@@ -108,26 +120,28 @@ export function buildLeaderboardMessage(daily: DailyChallengeResults): string {
   const remaining = sorted.length - top.length;
   const suffix = remaining > 0 ? `\n+${remaining} more` : "";
 
-  const sections = [
-    `**${title}**\n${participantLine}\n\n**Leaderboard**\n${summary}${suffix}`
-  ];
+  const sections = [`**${title}**\n${participantLine}`];
+  sections.push(`**Leaderboard**\n${wrapCodeBlock(`${summary}${suffix}`)}`);
 
   const roundLocations = formatRoundLocations(daily.roundLocations);
   if (roundLocations) {
-    sections.push(`**Round Locations**\n${roundLocations}`);
-    if (daily.roundLocations?.some((round) => round.locationName)) {
-      sections.push("_Location data © OpenStreetMap contributors._");
-    }
+    sections.push(`**Round Locations**\n${wrapCodeBlock(roundLocations)}`);
   } else {
-    sections.push("**Round Locations**\nRound locations: unavailable.");
+    sections.push(
+      `**Round Locations**\n${wrapCodeBlock("Round locations: unavailable.")}`
+    );
   }
 
   const playerBreakdowns = formatPlayerBreakdowns(sorted);
   if (playerBreakdowns) {
-    sections.push(`**Player Round Breakdowns**\n${playerBreakdowns}`);
+    sections.push(
+      `**Player Round Breakdowns**\n${wrapCodeBlock(playerBreakdowns)}`
+    );
   } else {
     sections.push(
-      "**Player Round Breakdowns**\nPlayer round breakdowns: unavailable."
+      `**Player Round Breakdowns**\n${wrapCodeBlock(
+        "Player round breakdowns: unavailable."
+      )}`
     );
   }
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -86,7 +86,7 @@ function formatPlayerBreakdowns(entries: DailyFriendResult[]): string | null {
       return sum + round.steps;
     }, 0) ?? 0;
     const totalsLine =
-      `Total: ${totalScore}pts | ${totalSteps}st | ${totalTime} | ${totalDistance}km`;
+      `Total: ${totalScore}pts | ${totalSteps}steps | ${totalTime} | ${totalDistance}km`;
 
     if (!friend.roundResults || friend.roundResults.length === 0) {
       const block = ["No round data.", totalsLine].join("\n");
@@ -146,7 +146,7 @@ export function buildLeaderboardMessage(daily: DailyChallengeResults): string {
 
   const playerBreakdowns = formatPlayerBreakdowns(sorted);
   if (playerBreakdowns) {
-    sections.push(`**Player Round Breakdowns**\n${playerBreakdowns}`);
+    sections.push(`**Player Round Breakdowns**\n\n${playerBreakdowns}`);
   } else {
     sections.push(
       `**Player Round Breakdowns**\n${wrapCodeBlock(

--- a/src/format.ts
+++ b/src/format.ts
@@ -86,7 +86,7 @@ function formatPlayerBreakdowns(entries: DailyFriendResult[]): string | null {
       return sum + round.steps;
     }, 0) ?? 0;
     const totalsLine =
-      `Total:\n ${totalScore} pts | ${totalSteps} steps | ${totalTime} | ${totalDistance} km`;
+      `Total: ${totalScore} pts | ${totalSteps} steps | ${totalTime} | ${totalDistance} km`;
 
     if (!friend.roundResults || friend.roundResults.length === 0) {
       const block = ["No round data.", totalsLine].join("\n");


### PR DESCRIPTION
### Motivation
```
- Improve readability of the Daily Friends message by adding visual medal markers, simplifying round location text, and making player round breakdowns easier to scan.
- Remove noisy coordinate and OpenStreetMap attribution lines and present only the city/location name when available.
- Present per-round data as a compact table and include per-player totals for points, steps, time, and distance.
```

### Description
```
- Add medal emojis for the top three entries via a `medals` array and include them in `buildLeaderboardSummary`.
- Simplify `formatRoundLocations` to emit only the `locationName` when present and return `Unknown location` when not, and remove coordinate formatting and OSM attribution.
- Change round row formatting in `formatRoundResults` to produce `Round | Steps | Score | Guess` style rows and use a fallback of `Unknown` for missing guesses.
- Update `formatPlayerBreakdowns` to emit a markdown-style table header, compute `totalSteps`, append a totals line (`Total: {points} pts | {steps} steps | {time} | {distance} km`), and wrap each top-level section in a monospaced code block via a new `wrapCodeBlock` helper in `src/format.ts`.
```

### Testing
```
- No automated tests were executed for this change.
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ed4f7ef748320bd5c60566c60f036)