### PR TITLE
Fix daily challenge target date selection

### DIFF
--- a/src/geoguessr.ts
+++ b/src/geoguessr.ts
@@ -196,14 +196,15 @@ function getTargetChallengeDay(
 ): string {
   const offsetMs = (closeHourUtc * 60 + closeMinuteUtc) * 60 * 1000;
   const shifted = new Date(now.getTime() - offsetMs);
-  const target = new Date(
+  return new Date(
     Date.UTC(
       shifted.getUTCFullYear(),
       shifted.getUTCMonth(),
-      shifted.getUTCDate() - 1
+      shifted.getUTCDate()
     )
-  );
-  return target.toISOString().slice(0, 10);
+  )
+    .toISOString()
+    .slice(0, 10);
 }
 
 async function fetchProfile(cookie: string): Promise<FriendSummary> {


### PR DESCRIPTION
### Motivation
- Fix the target date calculation so the app selects the correct daily challenge day after applying the close-time offset and avoids spurious "already posted" skips when the job runs before the close time.

### Description
- Update `getTargetChallengeDay` to return the UTC Y-M-D for the shifted time without subtracting an extra day, by using `Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate())` and `toISOString().slice(0, 10)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698537e276d88320ab39ca5f97c00739)